### PR TITLE
feat: genericize api utility function to accept non-json content types

### DIFF
--- a/packages/ads-library/src/api.ts
+++ b/packages/ads-library/src/api.ts
@@ -1,38 +1,87 @@
 import camelcaseKeys from "camelcase-keys";
 
-export function callJsonApi<Rq, Rsp>(options: {
+// HTTP request method options represented as a type
+export type ApiRequestMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+// base parameters for calling an API - common to all
+export interface BaseApiFetchOptions<RequestT> {
   url: string;
-  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  method: ApiRequestMethod;
+  // user-defined error message on failure
   errorMessage: string;
-  disableCamelize?: boolean;
-  body?: Rq;
-}): Promise<Rsp> {
+  // request body
+  body?: RequestT;
+}
+
+// Generic type to extend base api fetch options interface
+export type ExtendedApiFetchOptions<RequestT, ExtraOptionsT> =
+  BaseApiFetchOptions<RequestT> & ExtraOptionsT;
+
+// additional options for more flexible api calls
+export type ApiFetchOptions<RequestT> = ExtendedApiFetchOptions<
+  RequestT,
+  {
+    // Accept header
+    acceptType: string;
+    // Content-Type header
+    contentType: string;
+  }
+>;
+
+export type JsonApiFetchOptions<RequestT> = ExtendedApiFetchOptions<
+  RequestT,
+  {
+    // all JSON responses are camelized by default due to our Django backend convention
+    disableCamelize?: boolean;
+  }
+>;
+
+// calls our base callApi method and returns a json type, has option to disable response camel-casing
+export function callJsonApi<RequestT, ResponseT>(
+  options: JsonApiFetchOptions<RequestT>,
+): Promise<ResponseT> {
+  return (
+    callApi({
+      ...options,
+      body: options.body ? JSON.stringify(options.body) : undefined,
+      acceptType: "application/json",
+      contentType: "application/json",
+    })
+      .then((response) => response.json())
+      // camelize response keys unless disabled, cast to generic response type
+      .then((json) =>
+        options.disableCamelize
+          ? (json as ResponseT)
+          : (camelcaseKeys(json, { deep: true }) as ResponseT),
+      )
+  );
+}
+
+// generic interface on top of JS fetch function. adds:
+// - csrf token
+// - friendly interface for accept/content type
+// - error handling and logging consistent with ADS patterns
+export function callApi<RequestT extends BodyInit | null | undefined>(
+  options: ApiFetchOptions<RequestT>,
+): Promise<Response> {
   const request: RequestInit = {
     method: options.method,
     headers: {
       ...getCsrfHeader(),
-      Accept: "application/json",
-      "Content-Type": "application/json",
+      Accept: options.acceptType,
+      "Content-Type": options.contentType,
     },
+    body: options.body,
   };
-  if (options.body) {
-    request.body = JSON.stringify(options.body);
-  }
   return (
     fetch(options.url, request)
       .then((response) => {
         if (response.ok) {
-          return response.json();
+          return response;
         } else {
           throw new Error(options.errorMessage);
         }
       })
-      // camelize response keys unless disabled, cast to generic response type
-      .then((json) =>
-        options.disableCamelize
-          ? (json as Rsp)
-          : (camelcaseKeys(json, { deep: true }) as Rsp),
-      )
       // log error, return no response
       .catch((error) => {
         console.error(error);

--- a/packages/ads-library/src/api.ts
+++ b/packages/ads-library/src/api.ts
@@ -21,10 +21,10 @@ export type ExtendedApiFetchOptions<RequestT, ExtraOptionsT> =
 export type ApiFetchOptions<RequestT> = ExtendedApiFetchOptions<
   RequestT,
   {
-    // Accept header
+    // Accept header - what content type does the client / caller expect in return?
     acceptType: string;
-    // Content-Type header
-    contentType: string;
+    // Content-Type header - can omit for GET / DELETE / non-payload requests.
+    contentType?: string;
   }
 >;
 
@@ -69,10 +69,17 @@ export function callApi<RequestT extends BodyInit | null | undefined>(
     headers: {
       ...getCsrfHeader(),
       Accept: options.acceptType,
-      "Content-Type": options.contentType,
     },
     body: options.body,
   };
+  // to add optional Content-Type, we must reinitialize headers after type refinement
+  // since HeadersInit doesn't accept optional/mutable types.
+  if (options.contentType && request.headers) {
+    request.headers = {
+      ...request.headers,
+      "Content-Type": options.contentType,
+    };
+  }
   return (
     fetch(options.url, request)
       .then((response) => {

--- a/packages/ads-library/src/index.ts
+++ b/packages/ads-library/src/index.ts
@@ -1,5 +1,14 @@
 // publicly available library functions
 export { EventHelpers } from "./events";
-export { callJsonApi, getCsrfHeader } from "./api";
+export {
+  callApi,
+  callJsonApi,
+  getCsrfHeader,
+  ApiFetchOptions,
+  JsonApiFetchOptions,
+  ApiRequestMethod,
+  BaseApiFetchOptions,
+  ExtendedApiFetchOptions,
+} from "./api";
 export { UserOperatingSystem, getUserOS } from "./browser";
 export { humanBytes, formatDate } from "./formats";


### PR DESCRIPTION
- creates and exposes `callApi` function that is more generic than the existing `callJsonApi`, which now wraps around the base function that can now accept generic accept/content-types the user specifies.
- changes our internal type system to support the various options you can pass to each of these functions.