### PR TITLE
fix(api): update core API function to return Response object

### DIFF
--- a/packages/ads-library/src/api.ts
+++ b/packages/ads-library/src/api.ts
@@ -83,16 +83,16 @@ export function callApi<RequestT extends BodyInit | null | undefined>(
   return (
     fetch(options.url, request)
       .then((response) => {
-        if (response.ok) {
-          return response;
-        } else {
-          throw new Error(options.errorMessage);
+        if (!response.ok) {
+          // log user error message for non-200 level responses
+          console.error(options.errorMessage);
         }
+        return response;
       })
-      // log error, return no response
+      // log error message, bubble up exception
       .catch((error) => {
-        console.error(error);
-        return Promise.reject(options.errorMessage);
+        console.error(options.errorMessage);
+        return Promise.reject(error);
       })
   );
 }


### PR DESCRIPTION
- previously, non-200 responses would not return the `Response` object, which is problematic i.e. when trying to parse out error responses from a 400-level json Bad Request to inform the user the ways in which the request was bad.
- now, we correctly simply log the user-defined error message to sentry in cases of non-200 responses, and return the Response for the user to decide what to do with