### PR TITLE
bump ads-table version after publish

### DIFF
--- a/packages/ads-table/package.json
+++ b/packages/ads-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/ads-table",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "This is a table web component.",
   "main": "./src/index.ts",
   "module": "./dist/index.js",


### PR DESCRIPTION
`ads-table` version `1.0.2`
- https://github.com/internetarchive/ads-common/pull/10